### PR TITLE
Fixed the removeFromIndex() method

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -348,6 +348,10 @@ trait ElasticquentTrait
     public function removeFromIndex()
     {
         $params = $this->getBasicEsParams('write');
+
+        // Add the document key to delete
+        $params['id'] = $this->getKey();
+
         return $this->getElasticSearchClient()->delete($params);
     }
 


### PR DESCRIPTION
By passing the document id to the ES client's delete endpoint.