### PR TITLE
Made it so scroll uses a simple collection in the callback

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -359,7 +359,7 @@ trait ElasticquentTrait
             // On each chunk result set, we will pass them to the callback and then let the
             // developer take care of everything within the callback, which allows us to
             // keep the memory low for spinning through large result sets for working.
-            call_user_func($callback, new ResultCollection($results, $instance = new static));
+            call_user_func($callback, collect($results));
 
             $params = [
                 'scroll'    => $params['scroll'],


### PR DESCRIPTION
- Using a ResultCollection adds unneeded processing as it turns the results back into Eloquent models